### PR TITLE
Add editable lead details modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Simple Node.js CRM dashboard with a Kanban board for managing leads.
 - Create leads with contact info and description.
 - Drag-and-drop Kanban board with stages: not contacted, contacted, viewed property, offer given, closed, lost.
 - Data stored in `leads.json`.
+- Click on a lead card to view and edit all its details in a modal.
 
 ## Usage
 Run the server:

--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,5 @@
+let leadsData = [];
+
 async function fetchLeads() {
   const res = await fetch('/api/leads');
   return await res.json();
@@ -12,6 +14,7 @@ function createCard(lead) {
   card.addEventListener('dragstart', e => {
     e.dataTransfer.setData('id', lead.id);
   });
+  card.addEventListener('click', () => openLeadModal(lead));
   return card;
 }
 
@@ -24,8 +27,8 @@ function renderBoard(leads) {
 }
 
 async function load() {
-  const leads = await fetchLeads();
-  renderBoard(leads);
+  leadsData = await fetchLeads();
+  renderBoard(leadsData);
 }
 
 function setupDropZones() {
@@ -44,6 +47,40 @@ function setupDropZones() {
     });
   });
 }
+
+function openLeadModal(lead) {
+  const modal = document.getElementById('lead-modal');
+  const form = document.getElementById('lead-details-form');
+  form.dataset.id = lead.id;
+  form.name.value = lead.name || '';
+  form.email.value = lead.email || '';
+  form.phone.value = lead.phone || '';
+  form.street.value = lead.street || '';
+  form.city.value = lead.city || '';
+  form.postcode.value = lead.postcode || '';
+  form.description.value = lead.description || '';
+  form.offerPrice.value = lead.offerPrice || '';
+  modal.classList.remove('hidden');
+}
+
+function closeLeadModal() {
+  document.getElementById('lead-modal').classList.add('hidden');
+}
+
+document.getElementById('close-modal').addEventListener('click', closeLeadModal);
+
+document.getElementById('lead-details-form').addEventListener('submit', async e => {
+  e.preventDefault();
+  const id = e.target.dataset.id;
+  const data = Object.fromEntries(new FormData(e.target).entries());
+  await fetch('/api/leads/' + id, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  closeLeadModal();
+  load();
+});
 
 document.getElementById('lead-form').addEventListener('submit', async e => {
   e.preventDefault();

--- a/public/index.html
+++ b/public/index.html
@@ -47,6 +47,24 @@
     <div class="cards" id="lost"></div>
   </div>
 </section>
+
+<!-- Lead details modal -->
+<div id="lead-modal" class="modal hidden">
+  <div class="modal-content">
+    <span id="close-modal" class="close">&times;</span>
+    <form id="lead-details-form">
+      <input name="name" placeholder="Name" required>
+      <input name="email" placeholder="Email" required>
+      <input name="phone" placeholder="Phone" required>
+      <input name="street" placeholder="Street">
+      <input name="city" placeholder="City">
+      <input name="postcode" placeholder="Postcode">
+      <textarea name="description" placeholder="Description"></textarea>
+      <input name="offerPrice" placeholder="Offer Price">
+      <button type="submit">Save</button>
+    </form>
+  </div>
+</div>
 <script src="app.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,3 +5,30 @@ h1 { text-align: center; }
 .column h3 { text-align: center; }
 .cards { min-height: 100px; border: 1px dashed #ccc; padding: 5px; }
 .card { background: #e3e3e3; margin: 5px; padding: 5px; border-radius: 3px; cursor: move; }
+
+/* modal styling */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal.hidden {
+  display: none;
+}
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  max-width: 400px;
+  width: 100%;
+}
+.close {
+  float: right;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create lead details modal in HTML
- add modal styling
- open modal on lead card click, allow editing and saving
- document how to edit leads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b1cc0a78c8327a80c4d70a323de12